### PR TITLE
updated package.json; refactored code > imports/exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,36 @@
 {
     "name": "discord-audio-stream",
-    "version": "0.6.8",
+    "version": "0.6.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "discord-audio-stream",
-            "version": "0.6.8",
+            "version": "0.6.10",
             "dependencies": {
-                "@discordjs/opus": "^0.10.0",
                 "@discordjs/voice": "^0.18.0",
                 "@noble/ciphers": "^1.3.0",
                 "@stablelib/xchacha20poly1305": "^2.0.1",
-                "ffmpeg-static": "^5.2.0",
-                "libsodium-wrappers": "^0.7.15",
-                "opusscript": "^0.1.1",
                 "sodium-native": "^5.0.6"
             },
             "devDependencies": {
                 "@types/ejs": "^3.1.5",
-                "@types/node": "^24.0.10",
+                "@types/node": "^24.1.0",
                 "del-cli": "^6.0.0",
-                "npm-check-updates": "^18.0.1",
+                "npm-check-updates": "^18.0.2",
                 "tsup": "^8.5.0",
                 "typescript": "^5.8.3"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/FrauJulian"
+            },
+            "peerDependencies": {
+                "ffmpeg-static": "^5.2.0",
+                "libsodium-wrappers": "^0.7.15",
+                "opusscript": "^0.1.1"
             }
         },
         "node_modules/@derhuerst/http-basic": {
@@ -1084,9 +1091,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.0.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-            "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+            "version": "24.1.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+            "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.8.0"
@@ -2314,9 +2321,9 @@
             }
         },
         "node_modules/npm-check-updates": {
-            "version": "18.0.1",
-            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.0.1.tgz",
-            "integrity": "sha512-MO7mLp/8nm6kZNLLyPgz4gHmr9tLoU+pWPLdXuGAx+oZydBHkHWN0ibTonsrfwC2WEQNIQxuZagYwB67JQpAuw==",
+            "version": "18.0.2",
+            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.0.2.tgz",
+            "integrity": "sha512-9uVFZUCg5oDOcbzdsrJ4BEvq2gikd23tXuF5mqpl4mxVl051lzB00Xmd7ZVjVWY3XNUF3BQKWlN/qmyD8/bwrA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,25 @@
 {
     "name": "discord-audio-stream",
-    "version": "0.6.8",
+    "version": "0.6.10",
     "description": "NodeJS library to make stream any audio on discord easier.",
+    "exports": {
+        ".": {
+            "require": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            },
+            "import": {
+                "types": "./dist/index.d.mts",
+                "default": "./dist/index.mjs"
+            }
+        }
+    },
     "main": "./dist/index.js",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
+    "files": [
+        "dist"
+    ],
     "scripts": {
         "updateDependencies": "npx npm-check-updates --upgrade && npm install && echo SUCCEED UPDATE",
         "cleanSolution": "del-cli dist && echo SUCCEED CLEAN",
@@ -14,35 +29,48 @@
     },
     "repository": "https://github.com/FrauJulian/Discord-Audio-Stream",
     "bugs": "https://github.com/FrauJulian/Discord-Audio-Stream/issues",
+    "funding": "https://ko-fi.com/FrauJulian",
     "keywords": [
-        "discordjs-v14",
-        "stream",
+        "discordjs",
+        "discord.js",
+        "discord",
         "audio",
-        "music"
+        "voice",
+        "stream"
     ],
-    "author": {
-        "name": "Lechner Julian",
-        "nickname": "FrauJulian",
-        "email": "contact@fraujulian.xyz",
-        "website": "https://fraujulian.xyz/"
-    },
-    "private": false,
+    "contributors": [
+        {
+            "name": "Lechner Julian",
+            "nickname": "FrauJulian",
+            "email": "office@lechner-systems.at",
+            "website": "https://lechner-systems.at/"
+        }
+    ],
     "dependencies": {
-        "@discordjs/opus": "^0.10.0",
         "@discordjs/voice": "^0.18.0",
         "@noble/ciphers": "^1.3.0",
         "@stablelib/xchacha20poly1305": "^2.0.1",
-        "ffmpeg-static": "^5.2.0",
-        "libsodium-wrappers": "^0.7.15",
-        "opusscript": "^0.1.1",
         "sodium-native": "^5.0.6"
     },
     "devDependencies": {
         "@types/ejs": "^3.1.5",
-        "@types/node": "^24.0.10",
+        "@types/node": "^24.1.0",
         "del-cli": "^6.0.0",
-        "npm-check-updates": "^18.0.1",
+        "npm-check-updates": "^18.0.2",
         "tsup": "^8.5.0",
         "typescript": "^5.8.3"
+    },
+    "peerDependencies": {
+        "libsodium-wrappers": "^0.7.15",
+        "opusscript": "^0.1.1",
+        "ffmpeg-static": "^5.2.0"
+    },
+    "engines": {
+        "node": ">=18"
+    },
+    "private": false,
+    "publishConfig": {
+        "access": "public",
+        "provenance": true
     }
 }

--- a/src/Models/VoiceAudioDataModel.d.ts
+++ b/src/Models/VoiceAudioDataModel.d.ts
@@ -1,4 +1,4 @@
-export interface VoiceAudioDataModel {
+export default interface VoiceAudioDataModel {
     /**
      * The unique identifier for the audio resource.
      */

--- a/src/Models/VoiceConnectionDataModel.d.ts
+++ b/src/Models/VoiceConnectionDataModel.d.ts
@@ -1,6 +1,6 @@
-import {DiscordGatewayAdapterCreator} from "@discordjs/voice";
+import type {DiscordGatewayAdapterCreator} from "@discordjs/voice";
 
-export interface VoiceConnectionDataModel {
+export default interface VoiceConnectionDataModel {
     /**
      * The ID of the voice channel to connect to.
      */

--- a/src/Services/AudioManager.ts
+++ b/src/Services/AudioManager.ts
@@ -6,12 +6,12 @@ import {
     joinVoiceChannel,
     VoiceConnection
 } from "@discordjs/voice";
-import {IAudioManager} from "./IAudioManager";
-import {VoiceConnectionDataModel} from "../Models/VoiceConnectionDataModel";
-import {VoiceAudioDataModel} from "../Models/VoiceAudioDataModel";
+import type IAudioManager from "./IAudioManager";
+import type VoiceConnectionDataModel from "../Models/VoiceConnectionDataModel";
+import type VoiceAudioDataModel from "../Models/VoiceAudioDataModel";
 import {join} from "node:path";
 
-export class AudioManager implements IAudioManager {
+export default class AudioManager implements IAudioManager {
     public VoiceConnection: VoiceConnection | null = null;
     public AudioPlayer: AudioPlayer | null = null;
     public AudioResource: AudioResource | null = null;

--- a/src/Services/IAudioManager.ts
+++ b/src/Services/IAudioManager.ts
@@ -1,8 +1,7 @@
-import {AudioPlayer, AudioResource, VoiceConnection} from "@discordjs/voice";
-import {VoiceAudioDataModel} from "../Models/VoiceAudioDataModel";
-import {VoiceConnectionDataModel} from "../Models/VoiceConnectionDataModel";
+import type VoiceConnectionDataModel from "../Models/VoiceConnectionDataModel";
+import type VoiceAudioDataModel from "../Models/VoiceAudioDataModel";
 
-export interface IAudioManager {
+export default interface IAudioManager {
     OverrideOptions(connectionData?: VoiceConnectionDataModel | null, audioData?: VoiceAudioDataModel | null): void;
 
     CreateConnection(isRenew: boolean): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {AudioManager} from "./Services/AudioManager";
-export type {VoiceConnectionDataModel} from "./Models/VoiceConnectionDataModel";
-export type {VoiceAudioDataModel} from "./Models/VoiceAudioDataModel";
+export { default as AudioManager } from './Services/AudioManager';
+export type { default as VoiceConnectionDataModel } from './Models/VoiceConnectionDataModel';
+export type { default as VoiceAudioDataModel } from './Models/VoiceAudioDataModel';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,28 @@
 {
-    "compilerOptions": {
-        "strict": true,
-        "allowJs": false,
-        "noImplicitAny": true,
-        "esModuleInterop": true,
-        "strictNullChecks": true,
-        "target": "ES2022",
-        "moduleResolution": "Node",
-        "module": "CommonJS",
-        "declaration": true,
-        "isolatedModules": true,
-        "noEmit": true,
-        "outDir": "dist",
-        "types": [
-            "node"
-        ],
-        "typeRoots": [
-            "node_modules/@types"
-        ]
-    },
-
-    "include": ["src"],
-    "exclude": ["node_modules"]
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": false,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "strictNullChecks": true,
+    "target": "ES2022",
+    "moduleResolution": "Node",
+    "module": "CommonJS",
+    "declaration": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "outDir": "dist",
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "node_modules/@types"
+    ]
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "tsup";
- 
+import {defineConfig} from "tsup";
+
 export default defineConfig({
-    format: [ "cjs", "esm" ],
+    format: ["cjs", "esm"],
     entry: ["./src/index.ts"],
     dts: true,
     shims: true,


### PR DESCRIPTION
This pull request introduces several updates to improve the `discord-audio-stream` package, including enhancements to package metadata, restructuring of TypeScript imports, and changes to the export structure. The most important changes are summarized below.

### Package Metadata Enhancements:
- Added an `exports` field in `package.json` to specify module resolution paths for `require` and `import`. This improves compatibility with different module systems.
- Introduced `peerDependencies` for `libsodium-wrappers`, `opusscript`, and `ffmpeg-static`, ensuring better dependency management for consumers of the library.
- Added `funding` information in `package.json` to support the project's development and updated contributor details.

### TypeScript Import Restructuring:
- Changed imports in `src/Services/AudioManager.ts` and `src/Services/IAudioManager.ts` to use `type` imports for better type safety and clarity. [[1]](diffhunk://#diff-b36c542d0d1a85e78f0f3e683629b83aab6270b560ca4256030289c3eb5ef7f3L9-R14) [[2]](diffhunk://#diff-ab907611c4fea3d33a657878c3d8b36be6ff20451632ccc72099e204cdaae053L1-R4)

### Export Structure Updates:
- Modified `src/index.ts` to use `default` exports for `AudioManager`, `VoiceConnectionDataModel`, and `VoiceAudioDataModel`, aligning with the updated import structure.